### PR TITLE
Add basic CLI prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# 동시접속 앱 (QuietCoWork)
+
+간단한 CLI 인터페이스를 제공하는 실험적 하이브리드 앱 예시 코드입니다.
+
+## 사용법
+
+```bash
+python app.py list-rooms
+python app.py join study --goal "논문 작성" --timer 90
+```
+
+현재는 데모 목적으로 최소 기능만 구현되어 있습니다.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,74 @@
+import argparse
+from datetime import datetime
+
+ROOMS = {
+    "study": {
+        "name": "독서실",
+        "users": 12,
+        "description": "조용한 독서 공간"
+    },
+    "coding": {
+        "name": "코딩룸",
+        "users": 8,
+        "description": "키보드 소리 환영"
+    },
+    "meditation": {
+        "name": "명상실",
+        "users": 3,
+        "description": "완전한 고요"
+    }
+}
+
+
+def list_rooms():
+    print("[방 목록]")
+    for key, info in ROOMS.items():
+        print(f"{info['name']} ({info['users']}) - {info['description']}")
+
+
+def join_room(room, goal, timer):
+    if room not in ROOMS:
+        print(f"존재하지 않는 방: {room}")
+        return
+    info = ROOMS[room]
+    print(f"'{info['name']}'에 입장합니다. 목표: {goal}, 타이머: {timer}분")
+
+
+def show_theme():
+    hour = datetime.now().hour
+    if 6 <= hour < 12:
+        theme = "밝은 테마"
+    elif 12 <= hour < 18:
+        theme = "표준 테마"
+    else:
+        theme = "다크 테마"
+    print(f"현재 테마: {theme}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="QuietCoWork CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser("list-rooms")
+
+    join_parser = subparsers.add_parser("join")
+    join_parser.add_argument("room")
+    join_parser.add_argument("--goal", default="", help="현재 작업 목표")
+    join_parser.add_argument("--timer", type=int, default=60, help="분 단위 타이머")
+
+    subparsers.add_parser("theme")
+
+    args = parser.parse_args()
+
+    if args.command == "list-rooms":
+        list_rooms()
+    elif args.command == "join":
+        join_room(args.room, args.goal, args.timer)
+    elif args.command == "theme":
+        show_theme()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a short README with usage instructions
- create `app.py` implementing a simple CLI for listing rooms, joining a room, and showing the current theme

## Testing
- `python3 app.py list-rooms`
- `python3 app.py join study --goal test --timer 30`
- `python3 app.py theme`


------
https://chatgpt.com/codex/tasks/task_e_6888b0fb4adc8322b38957cc17a8de15