### PR TITLE
Add QuietCowork server/client demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# 동시접속(Quiet Co-Work) 데모
+
+간단한 웹소켓 기반의 CLI 하이브리드 협업 앱 예제입니다.
+
+## 구성
+- `quietcowork/server.py` : 방과 사용자 관리를 하는 웹소켓 서버
+- `quietcowork/client.py` : CLI 기반 클라이언트
+
+## 실행 방법
+1. 의존성 설치
+   ```bash
+   pip install websockets
+   ```
+2. 서버 실행
+   ```bash
+   python quietcowork/server.py
+   ```
+3. 클라이언트 실행
+   ```bash
+   python quietcowork/client.py <사용자이름> [ws://서버주소:포트]
+   ```
+   실행 후 `/join ROOM` 명령으로 방에 입장하고 메시지를 입력하면 됩니다.
+
+## 기능
+- 실시간 채팅 및 입장/퇴장 알림
+- 여러 방 지원
+
+이 코드는 버전3 목업을 기반으로 하며, 버전4 제안 사항 중 서버-클라이언트 구조와 기본 CLI 기능을 포함합니다.

--- a/quietcowork/client.py
+++ b/quietcowork/client.py
@@ -1,0 +1,56 @@
+import asyncio
+import json
+import websockets
+import sys
+import contextlib
+
+async def user_input(prompt: str = "> ") -> str:
+    return await asyncio.get_event_loop().run_in_executor(None, lambda: input(prompt))
+
+async def receiver(ws):
+    async for message in ws:
+        data = json.loads(message)
+        if data.get("type") == "message":
+            print(f"[{data['user']}]: {data['text']}")
+        elif data.get("type") == "status":
+            print(f"* {data['message']}")
+
+def print_help():
+    print("Commands:")
+    print("  /join ROOM - join a room")
+    print("  /exit - exit")
+    print("  /help - show this help")
+    print("Type anything else to send message")
+
+async def main(uri: str, username: str):
+    async with websockets.connect(uri) as ws:
+        print_help()
+        room = None
+        recv_task = asyncio.create_task(receiver(ws))
+        try:
+            while True:
+                msg = await user_input()
+                if msg.startswith("/join "):
+                    room = msg.split(maxsplit=1)[1]
+                    await ws.send(json.dumps({"type": "join", "room": room, "username": username}))
+                elif msg == "/exit":
+                    break
+                elif msg == "/help":
+                    print_help()
+                else:
+                    if not room:
+                        print("Join a room first using /join ROOM")
+                    else:
+                        await ws.send(json.dumps({"type": "message", "text": msg}))
+        finally:
+            recv_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await recv_task
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python client.py USERNAME [ws://host:port]")
+        sys.exit(1)
+    username = sys.argv[1]
+    uri = sys.argv[2] if len(sys.argv) > 2 else "ws://localhost:8765"
+    asyncio.run(main(uri, username))

--- a/quietcowork/server.py
+++ b/quietcowork/server.py
@@ -1,0 +1,48 @@
+import asyncio
+import json
+import websockets
+from websockets.server import WebSocketServerProtocol
+
+class Room:
+    def __init__(self):
+        self.clients = set()
+
+    async def broadcast(self, message: str):
+        if self.clients:
+            await asyncio.gather(*(client.send(message) for client in self.clients))
+
+class QuietCoworkServer:
+    def __init__(self):
+        self.rooms = {}
+
+    def get_room(self, room_name: str) -> Room:
+        if room_name not in self.rooms:
+            self.rooms[room_name] = Room()
+        return self.rooms[room_name]
+
+    async def handler(self, websocket: WebSocketServerProtocol):
+        room = None
+        username = "anonymous"
+        try:
+            async for message in websocket:
+                data = json.loads(message)
+                if data.get("type") == "join":
+                    room = self.get_room(data["room"])
+                    username = data.get("username", "anonymous")
+                    room.clients.add(websocket)
+                    await room.broadcast(json.dumps({"type": "status", "message": f"{username} joined {data['room']}"}))
+                elif data.get("type") == "message" and room:
+                    await room.broadcast(json.dumps({"type": "message", "user": username, "text": data["text"]}))
+        finally:
+            if room and websocket in room.clients:
+                room.clients.remove(websocket)
+                await room.broadcast(json.dumps({"type": "status", "message": f"{username} left"}))
+
+async def main(host: str = "localhost", port: int = 8765):
+    server = QuietCoworkServer()
+    async with websockets.serve(server.handler, host, port):
+        print(f"Server started on {host}:{port}")
+        await asyncio.Future()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a simple websocket server and CLI client
- include instructions in README

## Testing
- `pytest -q`
- `python3 -m py_compile quietcowork/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6888b0fb4adc8322b38957cc17a8de15